### PR TITLE
Split "parse" into "parseAttachment" and "parseBody"

### DIFF
--- a/component.json
+++ b/component.json
@@ -2,13 +2,13 @@
   "title": "EDIFACT Parser",
   "description": "Integration component that parses EDIFACT files",
   "actions": {
-    "parse-attachment": {
+    "parse_attachment": {
       "title": "Parse Attachment",
       "description": "Parses an incoming EDIFACT attachment",
       "main": "./lib/actions/parse.js",
       "metadata": {}
     },
-    "parse-body": {
+    "parse_body": {
       "title": "Parse Body",
       "description": "Parses an incoming EDIFACT body",
       "main": "./lib/actions/parse-body.js",

--- a/component.json
+++ b/component.json
@@ -2,10 +2,16 @@
   "title": "EDIFACT Parser",
   "description": "Integration component that parses EDIFACT files",
   "actions": {
-    "parse": {
-      "title": "Parse",
+    "parse-attachment": {
+      "title": "Parse Attachment",
       "description": "Parses an incoming EDIFACT attachment",
       "main": "./lib/actions/parse.js",
+      "metadata": {}
+    },
+    "parse-body": {
+      "title": "Parse Body",
+      "description": "Parses an incoming EDIFACT body",
+      "main": "./lib/actions/parse-body.js",
       "metadata": {}
     }
   }

--- a/lib/actions/parse-body.js
+++ b/lib/actions/parse-body.js
@@ -1,0 +1,73 @@
+/* eslint new-cap: [2, {"capIsNewExceptions": ["Q"]}] */
+const elasticio = require('elasticio-node');
+const messages = elasticio.messages;
+const edifact = require('edifact');
+const request = require('request');
+
+module.exports.process = processAction;
+
+
+/**
+ * This method will be called from elastic.io platform providing following data
+ *
+ * @param msg incoming message object that contains ``body`` with payload
+ * @param cfg configuration that is account information and configuration field values
+ */
+function processAction(msg) {
+  console.log('Incoming message=%j', msg);
+  let edifactMsg;
+  const that = this;
+  if (msg && msg.body && msg.body.length > 0) {
+    console.log('Found body %s attachment=%j', msg.body);
+    edifactMsg = msg.body;
+  } else {
+    console.error('body of the EDI file is missing');
+    this.emit('error', 'body of the EDI file is missing');
+    return this.emit('end');
+  }
+
+  const result = [];
+  let elements;
+  let components;
+
+  const validator = new edifact.Validator();
+  const parser = new edifact.Parser(validator);
+  validator.define(require('edifact/segments.js'));
+  validator.define(require('edifact/elements.js'));
+
+  parser.on('opensegment', function (segment) {
+    elements = [];
+    result.push({name: segment, elements: elements});
+  });
+
+  parser.on('closesegment', function () {});
+
+  parser.on('element', function () {
+    components = [];
+    elements.push(components);
+  });
+
+  parser.on('component', function (value) {
+    components.push(value);
+  });
+
+  parser.encoding('UNOA');
+
+  parser.on('end', function () {
+    console.log('End!');
+  });
+
+  parser.on('error', err => this.emit('error', err));
+
+  
+  console.log('Parsing EDIFACT: %s', edifactMsg);
+  parser.write(edifactMsg);
+  parser.end();
+  const body = {
+    result: result
+  };
+  console.log('Parsing result: %j', body);
+  that.emit('data', messages.newMessageWithBody(body));
+  that.emit('end');
+
+}

--- a/lib/actions/parse-body.js
+++ b/lib/actions/parse-body.js
@@ -2,7 +2,6 @@
 const elasticio = require('elasticio-node');
 const messages = elasticio.messages;
 const edifact = require('edifact');
-const request = require('request');
 
 module.exports.process = processAction;
 

--- a/lib/actions/parse-body.js
+++ b/lib/actions/parse-body.js
@@ -17,8 +17,8 @@ function processAction(msg) {
   let edifactMsg;
   const that = this;
   if (msg && msg.body) {
-    console.log('Found body %s', msg.body);
-    edifactMsg = msg.body;
+    console.log('Found body %s', JSON.stringify(msg.body));
+    edifactMsg = JSON.stringify(msg.body);
   } else {
     console.error('body of the EDI file is missing');
     this.emit('error', 'body of the EDI file is missing');

--- a/lib/actions/parse-body.js
+++ b/lib/actions/parse-body.js
@@ -17,8 +17,8 @@ function processAction(msg) {
   let edifactMsg;
   const that = this;
   if (msg && msg.body) {
-    console.log('Found body %s', JSON.stringify(msg.body));
-    edifactMsg = JSON.stringify(msg.body);
+    console.log('Found body %s', msg.body['body']);
+    edifactMsg = msg.body['body'];
   } else {
     console.error('body of the EDI file is missing');
     this.emit('error', 'body of the EDI file is missing');

--- a/lib/actions/parse-body.js
+++ b/lib/actions/parse-body.js
@@ -16,8 +16,8 @@ function processAction(msg) {
   console.log('Incoming message=%j', msg);
   let edifactMsg;
   const that = this;
-  if (msg && msg.body && msg.body.length > 0) {
-    console.log('Found body %s attachment=%j', msg.body);
+  if (msg && msg.body) {
+    console.log('Found body %s', msg.body);
     edifactMsg = msg.body;
   } else {
     console.error('body of the EDI file is missing');

--- a/lib/actions/parse.js
+++ b/lib/actions/parse.js
@@ -6,6 +6,7 @@ const request = require('request');
 
 module.exports.process = processAction;
 
+
 /**
  * This method will be called from elastic.io platform providing following data
  *


### PR DESCRIPTION
Currently only attachments can be parsed. For our customer we need the option for body to be parsed. This Pull Request renames the old "parse" method to "parseAttachment" and contains a new method "parseBody".